### PR TITLE
fix: add hover affordance to clickable inline file paths

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,8 @@ window.__ModuleLoader__.load({
           ".dsh-fm-reveal{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border:none;background:transparent;color:var(--dsw-alias-label-tertiary,#999);border-radius:4px;cursor:pointer;padding:0;margin-left:2px;vertical-align:baseline;}",
           ".dsh-fm-reveal:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,0.06));}",
           ".dsh-fm-reveal svg{display:block;}",
+          "code[data-fm-path]{cursor:pointer;color:var(--dsw-alias-link,#2f6fed);text-decoration:underline;text-decoration-style:dotted;}",
+          "code[data-fm-path]:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,0.08));border-radius:4px;}",
         ].join("\n");
         document.head.appendChild(tag);
       }
@@ -197,6 +199,7 @@ window.__ModuleLoader__.load({
           const text = (code.textContent || "").trim();
           if (text === "" || text.length > 300 || /^https?:\/\//i.test(text)) continue;
           if (!PATHISH.test(text)) continue;
+          code.dataset.fmPath = "1";
           const btn = document.createElement("button");
           btn.type = "button";
           btn.dataset.fmBtn = "1";


### PR DESCRIPTION
# fix: add hover affordance to clickable inline file paths

## Problem

Backtick-wrapped file paths inside conversation messages (e.g. `` `~/docs/plan.md` ``) are clickable via the document-level click delegation, but hovering over them gives **no visual affordance**: the `<code>` element keeps the default text cursor, no underline, no color change. Clicking works, but users cannot tell the path is clickable (reported on Chrome / macOS).

## Root cause

The plugin has two path mechanisms with asymmetric styling:

- **Bare paths outside the message area** (`processBarePaths`): wrapped in a `<span data-fm-inline>` with inline `cursor:pointer` + dotted link styling — fine.
- **Backtick paths in messages** (`processPathCodes`): rendered by the official renderer as `<code>` elements. The plugin only inserts the 📂 reveal button next to them and **never styles the `<code>` itself**. The injected `<style id="dsh-fm-style">` contains rules only for `.dsh-fm-reveal`.

So the click target (the `<code>`) is indistinguishable from plain inline code.

## Fix

1. In `processPathCodes`, mark path-like `<code>` elements with `data-fm-path`, using the **same `PATHISH` predicate** as the click handler, so the affordance appears exactly where clicks open files (and never on URLs / code blocks / buttons).
2. Extend the injected stylesheet with:

```css
code[data-fm-path]{cursor:pointer;color:var(--dsw-alias-link,#2f6fed);text-decoration:underline;text-decoration-style:dotted;}
code[data-fm-path]:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,0.08));border-radius:4px;}
```

The existing `MutationObserver` re-applies the marker after React re-renders, matching the reveal-button pattern (`data-fm-btn`).

## Verification

- Chrome (macOS): after the change, hovering a backtick path shows a pointer cursor, dotted underline, link color, and a subtle hover background; clicking still opens the file; reveal button unaffected.
- Click delegation, PATHISH matching, and the official deliverables coexistence are untouched.
- `node --check lib/client.js` passes.

## Notes

- No source tree exists in this repo (only committed `lib/`), so the change is applied to `lib/client.js` directly, consistent with how the repository is maintained.
- Light/dark themes follow the existing `--dsw-alias-*` design tokens; fallbacks are provided.
