### PR TITLE
fix: guard file routes against cross-origin requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ externally can never be whitelisted by mistake.
 
 - **Host** (`lib/index.js`): three routes — `/api/file-mentions/check` (existence check),
   `/api/file-mentions/open` (system open, `mode: open/reveal`, per-platform command) and
-  `/api/file-mentions/config` (whitelist read/write for the settings page, same-origin
-  guarded). Probe surface: absolute/`~/` paths are checked only inside the session cwd or
+  `/api/file-mentions/config` (whitelist read/write for the settings page). All three routes
+  are same-origin guarded. Probe surface: absolute/`~/` paths are checked only inside the session cwd or
   user-declared whitelist roots (stored via the official settings service — immediate
   effect, no restart); whitelist roots are protected against system disks and symlink
   escapes. Pure Node stdlib; `execFile` avoids shell injection.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,7 +87,7 @@ agent 回复里用反引号包路径（如 `` `~/docs/计划.md` ``）即可触�
 
 - **Host**（`lib/index.js`）：三条路由 —— `/api/file-mentions/check`（存在性验证）、
   `/api/file-mentions/open`（系统打开，`mode: open/reveal`，平台命令分流）、
-  `/api/file-mentions/config`（白名单读写，设置页用，同源校验防 CSRF）。
+  `/api/file-mentions/config`（白名单读写，设置页用）。三条路由均有同源校验防 CSRF。
   探测面：绝对/`~/` 路径只在本会话 cwd 内或用户声明的白名单根内探测（白名单走官方
   settings 服务，保存即生效、无需重启）；白名单根带系统盘保护与 symlink 防逃逸。
   全部 Node 标准库，`execFile` 不经 shell 防注入。

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,9 @@
  *   2. POST /api/file-mentions/open  —— 系统打开路径（{ sessionId, path, mode } → { ok }）
  *      mode: "open"（默认）= 默认应用打开文件 / 打开目录窗口（正文点击）
  *      mode: "reveal"             = Finder 定位选中文件 / 打开目录窗口（列表 📂 按钮）
- *   3. GET/POST /api/file-mentions/config —— 外置盘白名单读写（设置页用，isSameOrigin 防 CSRF）
+ *   3. GET/POST /api/file-mentions/config —— 外置盘白名单读写（设置页用）
+ *
+ * 所有路由均通过 isSameOrigin 防护本地 CSRF。
  *
  * 探测面（P1）：绝对/~ 路径只在本会话 cwd 内做存在性探测；cwd 之外只有
  * 用户显式声明的白名单根（设置页 extraProbeRoots）可探测——用户声明 = 授权
@@ -54,6 +56,10 @@ export function apply(ctx) {
     path: '/api/file-mentions/check',
     handler: async (req, res) => {
       try {
+        if (!isSameOrigin(req)) {
+          writeJson(res, 403, { valid: [], error: 'forbidden: cross-origin request' })
+          return
+        }
         const body = await readBody(req, MAX_BODY_BYTES)
         const sessionId = body && typeof body.sessionId === 'string' ? body.sessionId : null
         const paths = body && Array.isArray(body.paths)
@@ -106,6 +112,10 @@ export function apply(ctx) {
     path: '/api/file-mentions/open',
     handler: async (req, res) => {
       try {
+        if (!isSameOrigin(req)) {
+          writeJson(res, 403, { ok: false, error: 'forbidden: cross-origin request' })
+          return
+        }
         const body = await readBody(req, MAX_BODY_BYTES)
         const sessionId = body && typeof body.sessionId === 'string' ? body.sessionId : null
         const path = body && typeof body.path === 'string' && body.path !== '' ? body.path : null

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Clickable file paths in DSH replies: open files/directories from inline paths (Codex-style), with a mentioned-files chip list as fallback",
   "type": "module",
   "main": "lib/index.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "exports": {
     ".": "./lib/index.js",
     "./client": "./lib/client.js",

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import test from 'node:test'
+import { apply } from '../lib/index.js'
+
+function routes() {
+  const registered = new Map()
+  apply({
+    webServer: { register: (route) => (registered.set(route.path, route), () => undefined) },
+    sessions: { get: () => undefined, list: () => [] },
+    inject: () => undefined,
+    get: () => undefined,
+    effect: (mount) => { mount() },
+  })
+  return registered
+}
+
+function request(origin, body = '{}') {
+  const req = Readable.from([Buffer.from(body)])
+  req.headers = { origin, host: '127.0.0.1:3080' }
+  req.method = 'POST'
+  return req
+}
+
+function response() {
+  return {
+    status: undefined,
+    body: undefined,
+    writeHead(status) { this.status = status },
+    end(body) { this.body = JSON.parse(body) },
+  }
+}
+
+test('protects check and open from cross-origin requests', async () => {
+  for (const path of ['/api/file-mentions/check', '/api/file-mentions/open']) {
+    const res = response()
+    await routes().get(path).handler(request('https://evil.example'), res)
+    assert.equal(res.status, 403)
+    assert.match(res.body.error, /cross-origin/u)
+  }
+})
+
+test('keeps same-origin requests functional', async () => {
+  const res = response()
+  await routes().get('/api/file-mentions/check').handler(
+    request('http://127.0.0.1:3080', '{"sessionId":"missing","paths":["README.md"]}'),
+    res,
+  )
+  assert.equal(res.status, 400)
+  assert.deepEqual(res.body, { valid: [] })
+})


### PR DESCRIPTION
## Problem

The config route already rejects cross-origin requests, but the check and open routes did not apply the same guard. The open route has a local side effect, so every local file route should follow one origin policy.

## Change

- reuse the existing same-origin guard for check and open
- return HTTP 403 before reading a hostile request body
- document that all three routes are protected
- add the repository test command and focused regression tests

## Compatibility

Normal requests from the local DSH web app keep their existing behavior. The change adds no dependency and does not alter path resolution, whitelist handling, or platform-specific file opening.

## Verification

- `pnpm test`: 2 tests passed
- `node --check lib/index.js`
- `git diff --check upstream/main...HEAD`
